### PR TITLE
datadir on Linux

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -33,7 +33,7 @@ function Linux () {
   }
 
   this.datadir = function (appname) {
-    var prefix = process.env['XDG_CONFIG_HOME'] || (this.homedir() + './config')
+    var prefix = process.env['XDG_CONFIG_HOME'] || (this.homedir() + '/.config')
     return prefix + '/' + appname
   }
 }
@@ -48,7 +48,7 @@ function FreeBSD () {
   }
 
   this.datadir = function (appname) {
-    var prefix = process.env['XDG_CONFIG_HOME'] || (this.homedir() + './config')
+    var prefix = process.env['XDG_CONFIG_HOME'] || (this.homedir() + '/.config')
     return prefix + '/' + appname
   }
 }


### PR DESCRIPTION
XDG_CONFIG_HOME not defined on my system. $HOME./config can not be used but $HOME/.config work.